### PR TITLE
Updated Dockerfile - error adding the shared library libglasswall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,26 @@
 FROM glasswallsolutions/k8-centos7:latest as base
 RUN yum update && yum upgrade -y && yum install -y freetype*
 
-FROM base as source
-RUN yum install -y curl gcc make automake automake1.11 unzip && \
-    cd /tmp && mkdir c-icap
-COPY ./c-icap/ /tmp/c-icap/c-icap/
-COPY ./c-icap-modules /tmp/c-icap/c-icap-modules  
+FROM base as gwlib
 COPY ./Glasswall-Rebuild-SDK-Evaluation/Linux/Library/libglasswall.classic.so /usr/lib
 RUN echo "/usr/lib" > /etc/ld.so.conf.d/glasswall.classic.conf && ldconfig
 
+FROM gwlib as source
+RUN yum install -y curl gcc make libtool automake automake1.11 unzip && \
+    cd /tmp && mkdir c-icap
+COPY ./c-icap/ /tmp/c-icap/c-icap/
+COPY ./c-icap-modules /tmp/c-icap/c-icap-modules  
+
 FROM source as build    
 RUN cd /tmp/c-icap/c-icap &&  \
-    aclocal && autoconf && automake --add-missing && \
+    autoreconf -i -f && \
     ./configure --prefix=/usr/local/c-icap && make && make install
-    
 RUN cd /tmp/c-icap/c-icap-modules && \
-    aclocal && autoconf && automake --add-missing && \
+    autoreconf -i -f && \
     ./configure --with-c-icap=/usr/local/c-icap --prefix=/usr/local/c-icap && make && make install && \
     echo >> /usr/local/c-icap/etc/c-icap.conf && echo "Include gw_rebuild.conf" >> /usr/local/c-icap/etc/c-icap.conf
-    
-FROM base
+
+FROM gwlib
 COPY --from=build /usr/local/c-icap /usr/local/c-icap
 COPY --from=build /run/c-icap /run/c-icap
 COPY --from=build /usr/lib/libglasswall.classic.so /usr/lib/libglasswall.classic.so


### PR DESCRIPTION
The library originally was installed in to "source" but not "base" and it is from base that the final image is generated. 

Updated the Dockerfile to represent this and now if "ldconfig -p | grep glasswall.classic" is run it shows the shared library.